### PR TITLE
feature: regression tests auto CI check

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,7 +2,7 @@ name: Regression Tests
 
 on:
   pull_request:
-    types: [opened, synchronize]  # Trigger on new PR's and existing ones with new commits
+    types: [opened, synchronize]  # Trigger on new PR's and existing with new commits
     branches:
       - develop
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,7 +2,7 @@ name: Regression Tests
 
 on:
   pull_request:
-    types: [opened, synchronize]  # Trigger on new PR's and existing with new commits
+    types: [opened, synchronize]  # Trigger on new PR and existing with new commits
     branches:
       - develop
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,34 @@
+name: Regression Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]  # Trigger on new PR's and existing ones with new commits
+    branches:
+      - develop
+
+jobs:
+  deploy_devnet:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image (with proposed code changes) locally
+        id: build
+        run: |
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+              GITHUB_SHA_SHORT=$(jq -r .pull_request.head.sha "$GITHUB_EVENT_PATH" | cut -c 1-7)
+              echo $GITHUB_SHA_SHORT
+              echo "::set-output name=GITHUB_SHA_SHORT::$GITHUB_SHA_SHORT"
+          fi
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Run regression tests against JIT container image
+        uses: 0xPolygon/kurtosis-cdk@v0.1.9
+        with:
+          zkevm_bridge_service: ${{ steps.build.outputs.GITHUB_SHA_SHORT }}
+          kurtosis_cli: 0.89.3
+          kurtosis_cdk: v0.2.0


### PR DESCRIPTION
What does this PR do?
performs automatic regression detection checks when new code changes are proposed for 'develop' branch. specifically, behind the scenes, we spin up a lightweight cdk devnet (via k8s and kurtosis, fully within git action runner) and test a containerized version of the proposed code changes to ensure network operation and block production is sound under load tests and some bake time

Tests
run successfully within CI layer, as seen here: https://github.com/rebelArtists/agglayer/actions/runs/9008640654/job/24751163034